### PR TITLE
fix: update the repository link

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -4,7 +4,7 @@ description = "Model Context Protocol Server for Sequential Thinking"
 version = "0.0.1"
 schema_version = 1
 authors = ["Jeffrey Guenther <guenther.jeffrey@gmail.com>"]
-repository = "https://github.com/LoamStudios/zed-mcp-server-sequential-thinking"
+repository = "https://github.com/LoamStudios/zed-mcp-sequential-thinking"
 
 [context_servers.mcp-server-sequential-thinking]
 name = "Sequential Thinking MCP Server"


### PR DESCRIPTION
I had a 404 when looking for this repository on zed extension search. I Think it's a typo 